### PR TITLE
Add dismiss button props

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ These options are compatible with both `<Banner>` and `StaticBanner.show()`
     <td> 'Dismiss' </td>
   </tr>
   <tr>
+    <td> dismissButtonProps </td>
+    <td> object </td>
+    <td> Additional properties that can be passed to the default "Dismiss" button. See https://material-ui.com/api/button/</td>
+    <td> {} </td>
+  </tr>
+  <tr>
     <td> onClose </td>
     <td> function </td>
     <td> Callback invoked when clicking the Dismiss button. StaticBanner passes a close handler automatically </td>

--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -52,6 +52,7 @@ export default class Banner extends React.Component {
     buttonProps: PropTypes.object,
     showDismissButton: PropTypes.bool,
     dismissButtonLabel: PropTypes.string,
+    dismissButtonProps: PropTypes.object,
     onClose: PropTypes.func,
     icon: PropTypes.element,
     iconProps: PropTypes.object,
@@ -66,6 +67,7 @@ export default class Banner extends React.Component {
     buttonOnClick: () => {},
     showDismissButton: true,
     dismissButtonLabel: 'Dismiss',
+    dismissButtonProps: {},
     appBar: false,
     buttonComponent: ButtonBase,
     buttonProps: {},
@@ -83,6 +85,7 @@ export default class Banner extends React.Component {
       onClose,
       showDismissButton,
       dismissButtonLabel,
+      dismissButtonProps,
       buttonOnClick,
       buttonLabel,
       buttonComponent,
@@ -98,6 +101,7 @@ export default class Banner extends React.Component {
             <Button
               variant="text"
               onClick={onClose}
+              {...dismissButtonProps}
             >
               {dismissButtonLabel}
             </Button>

--- a/src/components/StaticBanner.jsx
+++ b/src/components/StaticBanner.jsx
@@ -19,6 +19,7 @@ export default class StaticBanner extends React.Component {
     buttonProps = {},
     showDismissButton = true,
     dismissButtonLabel = 'Dismiss',
+    dismissButtonProps = {},
     icon = null,
     iconProps = {},
   }) {
@@ -32,6 +33,7 @@ export default class StaticBanner extends React.Component {
           buttonOnClick,
           showDismissButton,
           dismissButtonLabel,
+          dismissButtonProps,
           icon,
           iconProps,
           buttonProps,
@@ -57,6 +59,7 @@ export default class StaticBanner extends React.Component {
         buttonProps: {},
         showDismissButton: true,
         dismissButtonLabel: 'Dismiss',
+        dismissButtonProps: {},
         icon: null,
         iconProps: {},
       },


### PR DESCRIPTION
I wanted to use this component but had a need for two buttons and to be able to customize the style of both. This change allows passing through props to the default dismiss button.