### PR TITLE
Replace React.memo with React.forwardRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.1-next] - 2020-12-04
+## [2.0.1-next] - 2020-12-08
 ### Changed
 - Replace React.memo with React.forwardRef and pass ref to the Collapse component
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1-next] - 2020-12-04
+### Changed
+- Replace React.memo with React.forwardRef and pass ref to the Collapse component
+
 ## [2.0.0-next] - 2020-12-04
 ### Changed
 - Updated all peerDependencies to support material-ui 5 (alpha 18)

--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -56,7 +56,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }), { name: 'MuiBanner' });
 
-const MuiBanner = React.memo(({
+const MuiBanner = React.forwardRef(({
   open,
   label,
   icon,
@@ -72,7 +72,7 @@ const MuiBanner = React.memo(({
   paperProps,
   cardProps,
   onClose,
-}) => {
+}, ref) => {
   const classes = useStyles();
 
   const hasButton = Boolean(showDismissButton || buttonLabel);
@@ -115,7 +115,7 @@ const MuiBanner = React.memo(({
   }
 
   return (
-    <Collapse in={open}>
+    <Collapse in={open} ref={ref}>
       <Paper elevation={0} className={classes.root} {...paperProps}>
         <Card elevation={0} {...containerProps} {...cardProps}>
           <CardContent


### PR DESCRIPTION
Changing from React.memo to React.forwardRef and passing the ref to the Collapse component.